### PR TITLE
Add Dependabot, pin actions to releases

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/docker-latest-trivy-check.yml
+++ b/.github/workflows/docker-latest-trivy-check.yml
@@ -32,7 +32,9 @@ jobs:
   publish-image:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Import Secrets
         uses: hashicorp/vault-action@v3
@@ -59,7 +61,7 @@ jobs:
         run: docker push "${{ inputs.GLOBAL_REPO_NAME }}/${{ inputs.GLOBAL_IMAGE_NAME }}"
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.30.0
         with:
           image-ref: "${{ inputs.GLOBAL_REPO_NAME }}/${{ inputs.GLOBAL_IMAGE_NAME }}"
           format: 'sarif'

--- a/.github/workflows/docker-latest.yml
+++ b/.github/workflows/docker-latest.yml
@@ -42,7 +42,9 @@ jobs:
   publish-image:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Import Secrets
         uses: hashicorp/vault-action@v3

--- a/.github/workflows/docker-release-static-version.yml
+++ b/.github/workflows/docker-release-static-version.yml
@@ -35,7 +35,9 @@ jobs:
   create-tag:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set user data
         run: |
@@ -74,9 +76,10 @@ jobs:
             ci/data/gh-workflows/maven-danubetech-nexus username | MAVEN_USERNAME ;
             ci/data/gh-workflows/maven-danubetech-nexus password | MAVEN_PASSWORD
 
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.GLOBAL_RELEASE_VERSION }}
+          persist-credentials: false
 
       - name: Set SHORT_SHA env variable
         id: short_sha

--- a/.github/workflows/docker-release-with-internal-dependency.yml
+++ b/.github/workflows/docker-release-with-internal-dependency.yml
@@ -37,7 +37,9 @@ jobs:
     outputs:
       version: ${{ steps.read_and_set_version.outputs.version }}
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Read and set version
         id: read_and_set_version
@@ -51,7 +53,9 @@ jobs:
     env:
       RELEASE_VERSION: ${{ needs.set-version.outputs.version }}
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set user data
         run: |
@@ -94,9 +98,10 @@ jobs:
         with:
           server_ids: danubetech-maven-releases,danubetech-maven-internal
 
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
         with:
           ref: ${{ env.RELEASE_VERSION }}
+          persist-credentials: false
 
       - name: Validate pom.xml
         run: |
@@ -138,9 +143,10 @@ jobs:
             ci/data/gh-workflows/maven-danubetech-nexus username | MAVEN_USERNAME ;
             ci/data/gh-workflows/maven-danubetech-nexus password | MAVEN_PASSWORD
 
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
         with:
           ref: ${{ env.RELEASE_VERSION }}
+          persist-credentials: false
 
       - name: Set SHORT_SHA env variable
         id: short_sha

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -63,9 +63,10 @@ jobs:
             ci/data/gh-workflows/${{ inputs.GLOBAL_REPO_NAME }} password | DOCKER_PASSWORD
 
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Configure Git
         run: |
@@ -145,10 +146,10 @@ jobs:
         run: |
           # Get current version without -SNAPSHOT
           CURRENT_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout | sed 's/-SNAPSHOT//')
-          
+
           # Split version into major and minor (we know it's in format X.Y)
           IFS='.' read -r major minor <<< "$CURRENT_VERSION"
-          
+
           # For patch releases, we need to use the last released version
           if [[ "${{ github.event.inputs.release_type }}" == "patch" ]]; then
             # Get the last version tag
@@ -178,17 +179,17 @@ jobs:
                 ;;
             esac
           fi
-          
+
           # Set release version
           mvn versions:set -DnewVersion=$RELEASE_VERSION
           mvn versions:commit
-          
+
           echo "RELEASE_VERSION=$RELEASE_VERSION" >> $GITHUB_ENV
-          
+
           # After creating release version, set the next development version
           mvn versions:set -DnewVersion=$NEXT_VERSION
           mvn versions:commit
-          
+
           # Only commit if there are changes to the pom.xml
           if git diff --quiet pom.xml; then
             echo "No changes to pom.xml, skipping commit"
@@ -204,10 +205,10 @@ jobs:
         run: |
           # Get current version
           CURRENT_VERSION=$(node -p "require('./package.json').version")
-          
+
           # Split version into major, minor, and patch
           IFS='.' read -r major minor patch <<< "$CURRENT_VERSION"
-          
+
           # Increment version based on release type
           case "${{ github.event.inputs.release_type }}" in
             major)
@@ -227,13 +228,13 @@ jobs:
               exit 1
               ;;
           esac
-          
+
           # Construct new version
           NEW_VERSION="${major}.${minor}.${patch}"
-          
+
           # Update package.json
           npm version $NEW_VERSION --no-git-tag-version
-          
+
           echo "RELEASE_VERSION=$NEW_VERSION" >> $GITHUB_ENV
           git add package.json package-lock.json
           git commit -m "[skip ci] Bump version $NEW_VERSION"
@@ -245,15 +246,15 @@ jobs:
         run: |
           # Get the last version tag
           LAST_VERSION=$(git tag -l | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n1)
-          
+
           if [[ -z "$LAST_VERSION" ]]; then
             echo "No version tags found. Starting with 0.1.0"
             LAST_VERSION="0.1.0"
           fi
-          
+
           # Split version into major, minor and patch
           IFS='.' read -r major minor patch <<< "$LAST_VERSION"
-          
+
           # Increment version based on release type
           case "${{ github.event.inputs.release_type }}" in
             major)
@@ -271,7 +272,7 @@ jobs:
               exit 1
               ;;
           esac
-          
+
           echo "RELEASE_VERSION=$RELEASE_VERSION" >> $GITHUB_ENV
 
       - name: Set SHORT_SHA env variable

--- a/.github/workflows/maven-release-internal.yml
+++ b/.github/workflows/maven-release-internal.yml
@@ -28,7 +28,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Import Secrets
         uses: hashicorp/vault-action@v3
         with:

--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -53,12 +53,14 @@ jobs:
         with:
           fetch-depth: 0
           ssh-key: ${{ secrets.DEPLOY_KEY }}
+          persist-credentials: false
 
       - name: Checkout code (Public repo)
         if: ${{ !inputs.USE_DEPLOY_KEY }}
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up JDK
         uses: actions/setup-java@v4
@@ -125,15 +127,15 @@ jobs:
         run: |
           # Get current version (e.g., 0.1-SNAPSHOT)
           CURRENT_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
-          
+
           # Extract components
           MAJOR_VERSION=$(echo $CURRENT_VERSION | sed -E 's/([0-9]+)\..*/\1/')
           MINOR_VERSION=$(echo $CURRENT_VERSION | sed -E 's/([0-9]+)\.([0-9]+).*/\2/')
           PATCH_VERSION=0
-          
+
           # Remove -SNAPSHOT and append .0 for release version (0.1-SNAPSHOT -> 0.1.0)
           RELEASE_VERSION=${CURRENT_VERSION%-SNAPSHOT}.0
-          
+
           # Calculate next development version based on RELEASE_TYPE
           case "${{ inputs.RELEASE_TYPE }}" in
             "major")
@@ -155,11 +157,11 @@ jobs:
               exit 1
               ;;
           esac
-          
+
           # Export for next steps
           echo "RELEASE_VERSION=$RELEASE_VERSION" >> $GITHUB_ENV
           echo "DEV_VERSION=$DEV_VERSION" >> $GITHUB_ENV
-          
+
           echo "Current version: $CURRENT_VERSION"
           echo "Release type: ${{ inputs.RELEASE_TYPE }}"
           echo "Release version: $RELEASE_VERSION"

--- a/.github/workflows/maven-snapshot.yml
+++ b/.github/workflows/maven-snapshot.yml
@@ -34,6 +34,7 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: false
 
       - name: Set up JDK
         uses: actions/setup-java@v4

--- a/.github/workflows/maven-triggered-docker-release.yml
+++ b/.github/workflows/maven-triggered-docker-release.yml
@@ -37,9 +37,10 @@ jobs:
     outputs:
       version: ${{ steps.read_and_set_version.outputs.version }}
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Fetches the whole repo including tags
+          persist-credentials: false
 
       - name: Read and set version
         id: read_and_set_version
@@ -60,9 +61,10 @@ jobs:
           secrets: |
             ci/data/gh-workflows/deployment-status slack-webhook-url | SLACK_WEBHOOK_URL
 
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
         with:
           ref: ${{ env.RELEASE_VERSION }}
+          persist-credentials: false
 
       - name: Validate pom.xml
         run: mvn validate -P ci
@@ -92,9 +94,10 @@ jobs:
             ci/data/gh-workflows/${{ inputs.GLOBAL_REPO_NAME }} username | DOCKER_USERNAME ;
             ci/data/gh-workflows/${{ inputs.GLOBAL_REPO_NAME }} password | DOCKER_PASSWORD
 
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
         with:
           ref: ${{ env.RELEASE_VERSION }}
+          persist-credentials: false
 
       - name: Set SHORT_SHA env variable
         id: short_sha

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -22,7 +22,9 @@ jobs:
   trivy-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Import Secrets
         uses: hashicorp/vault-action@v3
@@ -32,10 +34,10 @@ jobs:
           caCertificate: ${{ secrets.VAULTCA }}
           secrets: |
             ci/data/gh-workflows/${{ inputs.GLOBAL_REPO_NAME }} username | DOCKER_USERNAME ;
-            ci/data/gh-workflows/${{ inputs.GLOBAL_REPO_NAME }} password | DOCKER_PASSWORD 
+            ci/data/gh-workflows/${{ inputs.GLOBAL_REPO_NAME }} password | DOCKER_PASSWORD
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.30.0
         with:
           image-ref: "${{ inputs.GLOBAL_REPO_NAME }}/${{ inputs.GLOBAL_IMAGE_NAME }}"
           format: 'table'


### PR DESCRIPTION
* Add Dependabot to automate updates to Actions
* Set `persist-credentials=false` for `actions/checkout`
  * https://woodruffw.github.io/zizmor/audits/#artipacked
* Pin `actions/checkout` to `v4` instead of `master`
* Pin `aquasecurity/trivy-action` to `0.30.0` instead of `master`

---

Closes #10 