### PR TITLE
Use official Docker actions

### DIFF
--- a/.github/workflows/docker-latest-trivy-check.yml
+++ b/.github/workflows/docker-latest-trivy-check.yml
@@ -46,17 +46,40 @@ jobs:
             ci/data/gh-workflows/maven-danubetech-nexus username | MAVEN_USERNAME ;
             ci/data/gh-workflows/maven-danubetech-nexus password | MAVEN_PASSWORD
 
-      - name: Run build image action
-        run: |
-          docker build . -f "${{ inputs.PATH_TO_DOCKERFILE }}" -t "${{ inputs.GLOBAL_REPO_NAME }}/${{ inputs.GLOBAL_IMAGE_NAME }}" \
-          --build-arg DANUBETECH_MAVEN_INTERNAL_USERNAME=${{ env.MAVEN_USERNAME }} \
-          --build-arg DANUBETECH_MAVEN_INTERNAL_PASSWORD=${{ env.MAVEN_PASSWORD }}
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          install: true
+          version: latest
 
-      - name: Login user to repo
-        run: echo "${{ env.DOCKER_PASSWORD }}" | docker login "${{ inputs.GLOBAL_REPO_NAME }}" -u "${{ env.DOCKER_USERNAME }}" --password-stdin
+      - name: Docker Metadata
+        id: metadata
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ inputs.GLOBAL_REPO_NAME }}/${{ inputs.GLOBAL_IMAGE_NAME }}
+          tags: type=raw,value=latest
 
-      - name: Push image
-        run: docker push "${{ inputs.GLOBAL_REPO_NAME }}/${{ inputs.GLOBAL_IMAGE_NAME }}"
+      - name: Docker Login
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ inputs.GLOBAL_REPO_NAME }}
+          username: ${{ env.DOCKER_USERNAME }}
+          password: ${{ env.DOCKER_PASSWORD }}
+
+      - name: Docker Build and Push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ inputs.PATH_TO_DOCKERFILE }}
+          push: true
+          tags: ${{ steps.metadata.outputs.tags }}
+          labels: ${{ steps.metadata.outputs.labels }}
+          build-args: |
+            DANUBETECH_MAVEN_INTERNAL_USERNAME=${{ env.MAVEN_USERNAME }}
+            DANUBETECH_MAVEN_INTERNAL_PASSWORD=${{ env.MAVEN_PASSWORD }}
+          cache-from: type=gha,scope=docker-latest-trivy
+          cache-to: type=gha,scope=docker-latest-trivy,mode=max
+          platforms: linux/amd64
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master

--- a/.github/workflows/docker-latest.yml
+++ b/.github/workflows/docker-latest.yml
@@ -56,17 +56,40 @@ jobs:
             ci/data/gh-workflows/maven-danubetech-nexus username | MAVEN_USERNAME ;
             ci/data/gh-workflows/maven-danubetech-nexus password | MAVEN_PASSWORD
 
-      - name: Run build image action
-        run: |
-          docker build . -f "${{ inputs.PATH_TO_DOCKERFILE }}" -t "${{ inputs.GLOBAL_REPO_NAME }}/${{ inputs.GLOBAL_IMAGE_NAME }}" \
-          --build-arg DANUBETECH_MAVEN_INTERNAL_USERNAME=${{ env.MAVEN_USERNAME }} \
-          --build-arg DANUBETECH_MAVEN_INTERNAL_PASSWORD=${{ env.MAVEN_PASSWORD }}
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          install: true
+          version: latest
 
-      - name: Login user to repo
-        run: echo "${{ env.DOCKER_PASSWORD }}" | docker login "${{ inputs.GLOBAL_REPO_NAME }}" -u "${{ env.DOCKER_USERNAME }}" --password-stdin
+      - name: Docker Metadata
+        id: metadata
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ inputs.GLOBAL_REPO_NAME }}/${{ inputs.GLOBAL_IMAGE_NAME }}
+          tags: type=raw,value=latest
 
-      - name: Push image
-        run: docker push "${{ inputs.GLOBAL_REPO_NAME }}/${{ inputs.GLOBAL_IMAGE_NAME }}"
+      - name: Docker Login
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ inputs.GLOBAL_REPO_NAME }}
+          username: ${{ env.DOCKER_USERNAME }}
+          password: ${{ env.DOCKER_PASSWORD }}
+
+      - name: Docker Build and Push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ inputs.PATH_TO_DOCKERFILE }}
+          push: true
+          tags: ${{ steps.metadata.outputs.tags }}
+          labels: ${{ steps.metadata.outputs.labels }}
+          build-args: |
+            DANUBETECH_MAVEN_INTERNAL_USERNAME=${{ env.MAVEN_USERNAME }}
+            DANUBETECH_MAVEN_INTERNAL_PASSWORD=${{ env.MAVEN_PASSWORD }}
+          cache-from: type=gha,scope=docker-latest
+          cache-to: type=gha,scope=docker-latest,mode=max
+          platforms: linux/amd64
 
       - name: Slack notification
         if: failure()

--- a/.github/workflows/docker-release-static-version.yml
+++ b/.github/workflows/docker-release-static-version.yml
@@ -78,21 +78,45 @@ jobs:
         with:
           ref: ${{ inputs.GLOBAL_RELEASE_VERSION }}
 
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          install: true
+          version: latest
+
       - name: Set SHORT_SHA env variable
         id: short_sha
-        run: echo "::set-output name=SHORT_SHA::$(git rev-parse --short HEAD)"
+        run: echo "SHORT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
-      - name: Build image
-        run: |
-          docker build . -f "${{ inputs.PATH_TO_DOCKERFILE }}" -t "${{ inputs.GLOBAL_REPO_NAME }}/${{ inputs.GLOBAL_IMAGE_NAME }}:${{ inputs.GLOBAL_RELEASE_VERSION }}-${{ steps.short_sha.outputs.SHORT_SHA }}" \
-          --build-arg DANUBETECH_MAVEN_INTERNAL_USERNAME=${{ env.MAVEN_USERNAME }} \
-          --build-arg DANUBETECH_MAVEN_INTERNAL_PASSWORD=${{ env.MAVEN_PASSWORD }}
+      - name: Docker Metadata
+        id: metadata
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ inputs.GLOBAL_REPO_NAME }}/${{ inputs.GLOBAL_IMAGE_NAME }}
+          tags: |
+            type=raw,value=${{ inputs.GLOBAL_RELEASE_VERSION }}-${{ steps.short_sha.outputs.SHORT_SHA }}
 
-      - name: Login user to repo
-        run: echo "${{ env.DOCKER_PASSWORD }}" | docker login "${{ inputs.GLOBAL_REPO_NAME }}" -u "${{ env.DOCKER_USERNAME }}" --password-stdin
+      - name: Docker Login
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ inputs.GLOBAL_REPO_NAME }}
+          username: ${{ env.DOCKER_USERNAME }}
+          password: ${{ env.DOCKER_PASSWORD }}
 
-      - name: Push image
-        run: docker push "${{ inputs.GLOBAL_REPO_NAME }}/${{ inputs.GLOBAL_IMAGE_NAME }}:${{ inputs.GLOBAL_RELEASE_VERSION }}-${{ steps.short_sha.outputs.SHORT_SHA }}"
+      - name: Docker Build and Push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ inputs.PATH_TO_DOCKERFILE }}
+          push: true
+          tags: ${{ steps.metadata.outputs.tags }}
+          labels: ${{ steps.metadata.outputs.labels }}
+          build-args: |
+            DANUBETECH_MAVEN_INTERNAL_USERNAME=${{ env.MAVEN_USERNAME }}
+            DANUBETECH_MAVEN_INTERNAL_PASSWORD=${{ env.MAVEN_PASSWORD }}
+          cache-from: type=gha,scope=docker-release-static
+          cache-to: type=gha,scope=docker-release-static,mode=max
+          platforms: linux/amd64
 
       - name: Slack notification
         if: failure()

--- a/.github/workflows/docker-release-with-internal-dependency.yml
+++ b/.github/workflows/docker-release-with-internal-dependency.yml
@@ -142,21 +142,45 @@ jobs:
         with:
           ref: ${{ env.RELEASE_VERSION }}
 
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          install: true
+          version: latest
+
       - name: Set SHORT_SHA env variable
         id: short_sha
-        run: echo "::set-output name=SHORT_SHA::$(git rev-parse --short HEAD)"
+        run: echo "SHORT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
-      - name: Build image
-        run: |
-          docker build . -f "${{ inputs.PATH_TO_DOCKERFILE }}" -t "${{ inputs.GLOBAL_REPO_NAME }}/${{ inputs.GLOBAL_IMAGE_NAME }}:${{ env.RELEASE_VERSION }}-${{ steps.short_sha.outputs.SHORT_SHA }}" \
-          --build-arg DANUBETECH_MAVEN_INTERNAL_USERNAME=${{ env.MAVEN_USERNAME }} \
-          --build-arg DANUBETECH_MAVEN_INTERNAL_PASSWORD=${{ env.MAVEN_PASSWORD }}
+      - name: Docker Metadata
+        id: metadata
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ inputs.GLOBAL_REPO_NAME }}/${{ inputs.GLOBAL_IMAGE_NAME }}
+          tags: |
+            type=raw,value=${{ env.RELEASE_VERSION }}-${{ steps.short_sha.outputs.SHORT_SHA }}
 
-      - name: Login user to repo
-        run: echo "${{ env.DOCKER_PASSWORD }}" | docker login "${{ inputs.GLOBAL_REPO_NAME }}" -u "${{ env.DOCKER_USERNAME }}" --password-stdin
+      - name: Docker Login
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ inputs.GLOBAL_REPO_NAME }}
+          username: ${{ env.DOCKER_USERNAME }}
+          password: ${{ env.DOCKER_PASSWORD }}
 
-      - name: Push image
-        run: docker push "${{ inputs.GLOBAL_REPO_NAME }}/${{ inputs.GLOBAL_IMAGE_NAME }}:${{ env.RELEASE_VERSION }}-${{ steps.short_sha.outputs.SHORT_SHA }}"
+      - name: Docker Build and Push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ inputs.PATH_TO_DOCKERFILE }}
+          push: true
+          tags: ${{ steps.metadata.outputs.tags }}
+          labels: ${{ steps.metadata.outputs.labels }}
+          build-args: |
+            DANUBETECH_MAVEN_INTERNAL_USERNAME=${{ env.MAVEN_USERNAME }}
+            DANUBETECH_MAVEN_INTERNAL_PASSWORD=${{ env.MAVEN_PASSWORD }}
+          cache-from: type=gha,scope=docker-release-internal
+          cache-to: type=gha,scope=docker-release-internal,mode=max
+          platforms: linux/amd64
 
       - name: Slack notification
         if: failure()

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -145,10 +145,10 @@ jobs:
         run: |
           # Get current version without -SNAPSHOT
           CURRENT_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout | sed 's/-SNAPSHOT//')
-          
+
           # Split version into major and minor (we know it's in format X.Y)
           IFS='.' read -r major minor <<< "$CURRENT_VERSION"
-          
+
           # For patch releases, we need to use the last released version
           if [[ "${{ github.event.inputs.release_type }}" == "patch" ]]; then
             # Get the last version tag
@@ -178,17 +178,17 @@ jobs:
                 ;;
             esac
           fi
-          
+
           # Set release version
           mvn versions:set -DnewVersion=$RELEASE_VERSION
           mvn versions:commit
-          
+
           echo "RELEASE_VERSION=$RELEASE_VERSION" >> $GITHUB_ENV
-          
+
           # After creating release version, set the next development version
           mvn versions:set -DnewVersion=$NEXT_VERSION
           mvn versions:commit
-          
+
           # Only commit if there are changes to the pom.xml
           if git diff --quiet pom.xml; then
             echo "No changes to pom.xml, skipping commit"
@@ -204,10 +204,10 @@ jobs:
         run: |
           # Get current version
           CURRENT_VERSION=$(node -p "require('./package.json').version")
-          
+
           # Split version into major, minor, and patch
           IFS='.' read -r major minor patch <<< "$CURRENT_VERSION"
-          
+
           # Increment version based on release type
           case "${{ github.event.inputs.release_type }}" in
             major)
@@ -227,13 +227,13 @@ jobs:
               exit 1
               ;;
           esac
-          
+
           # Construct new version
           NEW_VERSION="${major}.${minor}.${patch}"
-          
+
           # Update package.json
           npm version $NEW_VERSION --no-git-tag-version
-          
+
           echo "RELEASE_VERSION=$NEW_VERSION" >> $GITHUB_ENV
           git add package.json package-lock.json
           git commit -m "[skip ci] Bump version $NEW_VERSION"
@@ -245,15 +245,15 @@ jobs:
         run: |
           # Get the last version tag
           LAST_VERSION=$(git tag -l | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n1)
-          
+
           if [[ -z "$LAST_VERSION" ]]; then
             echo "No version tags found. Starting with 0.1.0"
             LAST_VERSION="0.1.0"
           fi
-          
+
           # Split version into major, minor and patch
           IFS='.' read -r major minor patch <<< "$LAST_VERSION"
-          
+
           # Increment version based on release type
           case "${{ github.event.inputs.release_type }}" in
             major)
@@ -271,29 +271,61 @@ jobs:
               exit 1
               ;;
           esac
-          
+
           echo "RELEASE_VERSION=$RELEASE_VERSION" >> $GITHUB_ENV
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          install: true
+          version: latest
 
       - name: Set SHORT_SHA env variable
         id: short_sha
         run: echo "SHORT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
-      - name: Build image maven
+      - name: Docker Metadata
+        id: metadata
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ inputs.GLOBAL_REPO_NAME }}/${{ inputs.GLOBAL_IMAGE_NAME }}
+          tags: |
+            type=raw,value=${{ env.RELEASE_VERSION }}-${{ steps.short_sha.outputs.SHORT_SHA }}
+
+      - name: Docker Login
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ inputs.GLOBAL_REPO_NAME }}
+          username: ${{ env.DOCKER_USERNAME }}
+          password: ${{ env.DOCKER_PASSWORD }}
+
+      - name: Docker Build and Push (maven)
+        uses: docker/build-push-action@v6
         if: ${{ inputs.GLOBAL_FRAMEWORK == 'maven' || inputs.GLOBAL_FRAMEWORK == 'triggered' || inputs.GLOBAL_FRAMEWORK == 'did-science' }}
-        run: |
-          docker build . -f "${{ inputs.PATH_TO_DOCKERFILE }}" -t "${{ inputs.GLOBAL_REPO_NAME }}/${{ inputs.GLOBAL_IMAGE_NAME }}:${{ env.RELEASE_VERSION }}-${{ steps.short_sha.outputs.SHORT_SHA }}" \
-          --build-arg DANUBETECH_MAVEN_INTERNAL_USERNAME=${{ env.MAVEN_USERNAME }} \
-          --build-arg DANUBETECH_MAVEN_INTERNAL_PASSWORD=${{ env.MAVEN_PASSWORD }}
+        with:
+          context: .
+          file: ${{ inputs.PATH_TO_DOCKERFILE }}
+          push: true
+          tags: ${{ steps.metadata.outputs.tags }}
+          build-args: |
+            DANUBETECH_MAVEN_INTERNAL_USERNAME=${{ env.MAVEN_USERNAME }}
+            DANUBETECH_MAVEN_INTERNAL_PASSWORD=${{ env.MAVEN_PASSWORD }}
+          cache-from: type=gha,scope=docker-release-mvn
+          cache-to: type=gha,scope=docker-release-mvn,mode=max
+          platforms: linux/amd64
 
-      - name: Build image generic
+      - name: Docker Build and Push (generic)
+        uses: docker/build-push-action@v6
         if: ${{ inputs.GLOBAL_FRAMEWORK != 'maven' && inputs.GLOBAL_FRAMEWORK != 'triggered' && inputs.GLOBAL_FRAMEWORK != 'did-science' }}
-        run: |
-          docker build . -f "${{ inputs.PATH_TO_DOCKERFILE }}" -t "${{ inputs.GLOBAL_REPO_NAME }}/${{ inputs.GLOBAL_IMAGE_NAME }}:${{ env.RELEASE_VERSION }}-${{ steps.short_sha.outputs.SHORT_SHA }}"
-
-      - name: Login user to repo and push image
-        run: |
-          echo "${{ env.DOCKER_PASSWORD }}" | docker login "${{ inputs.GLOBAL_REPO_NAME }}" -u "${{ env.DOCKER_USERNAME }}" --password-stdin
-          docker push "${{ inputs.GLOBAL_REPO_NAME }}/${{ inputs.GLOBAL_IMAGE_NAME }}:${{ env.RELEASE_VERSION }}-${{ steps.short_sha.outputs.SHORT_SHA }}"
+        with:
+          context: .
+          file: ${{ inputs.PATH_TO_DOCKERFILE }}
+          push: true
+          tags: ${{ steps.metadata.outputs.tags }}
+          labels: ${{ steps.metadata.outputs.labels }}
+          cache-from: type=gha,scope=docker-release
+          cache-to: type=gha,scope=docker-release,mode=max
+          platforms: linux/amd64
 
       - name: Create and Push Git Tag
         if: success() && (steps.increment-version-maven.outcome == 'success' || steps.increment-version-node.outcome == 'success' || steps.increment-version-git.outcome == 'success')

--- a/.github/workflows/maven-triggered-docker-release.yml
+++ b/.github/workflows/maven-triggered-docker-release.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Read and set version
         id: read_and_set_version
-        run: echo "::set-output name=version::$(git describe --abbrev=0)"
+        run: echo version=$(git describe --abbrev=0) >> $GITHUB_OUTPUT
 
   validate-pom:
     needs: set-version
@@ -96,18 +96,42 @@ jobs:
         with:
           ref: ${{ env.RELEASE_VERSION }}
 
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          install: true
+          version: latest
+
       - name: Set SHORT_SHA env variable
         id: short_sha
-        run: echo "::set-output name=SHORT_SHA::$(git rev-parse --short HEAD)"
+        run: echo "SHORT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
-      - name: Build image
-        run: docker build . -f "${{ inputs.PATH_TO_DOCKERFILE }}" -t "${{ inputs.GLOBAL_REPO_NAME }}/${{ inputs.GLOBAL_IMAGE_NAME }}:${{ env.RELEASE_VERSION }}-${{ steps.short_sha.outputs.SHORT_SHA }}"
+      - name: Docker Metadata
+        id: metadata
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ inputs.GLOBAL_REPO_NAME }}/${{ inputs.GLOBAL_IMAGE_NAME }}
+          tags: |
+            type=raw,value=${{ env.RELEASE_VERSION }}-${{ steps.short_sha.outputs.SHORT_SHA }}
 
-      - name: Login user to repo
-        run: echo "${{ env.DOCKER_PASSWORD }}" | docker login "${{ inputs.GLOBAL_REPO_NAME }}" -u "${{ env.DOCKER_USERNAME }}" --password-stdin
+      - name: Docker Login
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ inputs.GLOBAL_REPO_NAME }}
+          username: ${{ env.DOCKER_USERNAME }}
+          password: ${{ env.DOCKER_PASSWORD }}
 
-      - name: Push image
-        run: docker push "${{ inputs.GLOBAL_REPO_NAME }}/${{ inputs.GLOBAL_IMAGE_NAME }}:${{ env.RELEASE_VERSION }}-${{ steps.short_sha.outputs.SHORT_SHA }}"
+      - name: Docker Build and Push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ inputs.PATH_TO_DOCKERFILE }}
+          push: true
+          tags: ${{ steps.metadata.outputs.tags }}
+          labels: ${{ steps.metadata.outputs.labels }}
+          cache-from: type=gha,scope=mvn-trig-docker-release
+          cache-to: type=gha,scope=mvn-trig-docker-release,mode=max
+          platforms: linux/amd64
 
       - name: Slack notification
         if: failure()


### PR DESCRIPTION
- Replace direct Docker CLI commands with official GitHub Actions:
  - `docker/setup-buildx-action@v3` for enhanced build capabilities
  - `docker/metadata-action@v5` for standardized tag management
  - `docker/login-action@v3` for secure registry authentication
  - `docker/build-push-action@v6` for optimized build and push operations
- Implement Docker layer caching with GitHub Actions cache:
  - Add `cache-from` and `cache-to` parameters
  - Configure separate cache scopes for different workflows
  - Set `mode=max` for optimal caching efficiency
- Update deprecated GitHub Actions syntax:
  - Replace `::set-output` with `>> $GITHUB_OUTPUT`
- Add platform targeting:
  - Explicitly specify `platforms: linux/amd64` for all builds
    - This will change in part 2 of #7
- Standardize Docker operations across all workflows for better maintainability

---

Closes #11